### PR TITLE
Corrigir simulação de divisões e legenda

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -322,3 +322,90 @@ O FootManager 98 está agora **TOTALMENTE FUNCIONAL** com todas as correções c
 - **Análise do Schema:** Identificadas relações Manager ↔ Lineup, Manager ↔ Tactic, Manager ↔ SaveSlot
 - **Ordem de Exclusão Corrigida:** lineup → tactic → saveSlot → manager
 - **Logs de Debug:** Adicionados para acompanhar o processo de reset
+
+## 🚨 NOVOS PROBLEMAS IDENTIFICADOS - 28/12/2024
+
+### 1. ✅ **Simulação de outras divisões não funciona corretamente** - CORRIGIDO
+**Problema:** A função que executa as partidas usa o `roundId` da rodada do clube do jogador para buscar todos os confrontos a serem simulados. Cada divisão possui seu próprio registro de rodada (mesmo número de rodada, mas com `roundId` diferente), portanto o filtro por `roundId` só recupera as partidas da divisão do jogador. Assim, quando você joga sua partida apenas a sua divisão avança; as divisões controladas pelo computador ficam estagnadas.
+
+**Impacto:** Apenas a divisão do jogador progride, outras divisões ficam paradas
+
+**Correção implementada:** 
+```typescript
+// ANTES:
+const roundFixtures = await prisma.fixture.findMany({
+  where: {
+    roundId: playerFixture.roundId, // ❌ Apenas partidas da divisão do jogador
+    isPlayed: false
+  }
+})
+
+// DEPOIS:
+const { number: roundNumber, seasonId } = playerFixture.round
+const roundFixtures = await prisma.fixture.findMany({
+  where: {
+    round: { 
+      number: roundNumber, 
+      seasonId 
+    }, // ✅ Todas as divisões na mesma rodada
+    isPlayed: false
+  }
+})
+```
+
+**Status:** ✅ CORRIGIDO - Agora todas as divisões avançam juntas quando o jogador joga sua partida
+
+### 2. ✅ **Legenda estática em AllDivisionsView** - CORRIGIDO
+**Problema:** No componente `AllDivisionsView` a legenda é fixa: sempre exibe "Promoção" (verde), "Rebaixamento" (vermelho), "Eliminação (Série D)" (preto) e "Permanecem" (cinza). Entretanto, a Série A não tem promoção, e a Série D não tem rebaixamento. Por isso, as cores da legenda não combinam com as linhas da tabela.
+
+**Impacto:** Confusão visual - legenda mostra cores que não existem para a divisão selecionada
+
+**Correção implementada:** 
+```typescript
+const getLegendItems = (level: number) => {
+  if (level === 1) {
+    return [
+      { color: 'bg-retro-red', label: 'Rebaixamento' },
+      { color: 'bg-retro-gray', label: 'Permanecem na Divisão' }
+    ]
+  } else if (level === 4) {
+    return [
+      { color: 'bg-retro-green', label: 'Promoção' },
+      { color: 'bg-retro-dark', label: 'Eliminação (Série D)' },
+      { color: 'bg-retro-gray', label: 'Permanecem na Divisão' }
+    ]
+  } else {
+    return [
+      { color: 'bg-retro-green', label: 'Promoção' },
+      { color: 'bg-retro-red', label: 'Rebaixamento' },
+      { color: 'bg-retro-gray', label: 'Permanecem na Divisão' }
+    ]
+  }
+}
+```
+
+**Status:** ✅ CORRIGIDO - Legenda agora mostra apenas as cores relevantes para cada divisão
+
+## 🎉 CORREÇÕES IMPLEMENTADAS COM SUCESSO - 28/12/2024
+
+✅ **Simulação de todas as divisões:** Agora funciona corretamente usando `roundNumber` e `seasonId`
+✅ **Legenda dinâmica:** Exibe apenas as cores relevantes para cada divisão selecionada
+
+O jogo continua 100% funcional com estas novas melhorias!
+
+## 🎄 ATUALIZAÇÃO 24/12/2024: TODAS AS CORREÇÕES IMPLEMENTADAS!
+
+O FootManager 98 está agora **TOTALMENTE FUNCIONAL** com todas as correções críticas implementadas:
+
+- ✅ **Botões principais**: Todos funcionando (Avançar dia, Simular, Jogar partida)
+- ✅ **Sistema de escalação**: Dinâmico e respeitando formações táticas
+- ✅ **Exibição de informações**: Jogos, tabelas e divisões funcionando
+- ✅ **APIs corrigidas**: Divisões e standings com endpoints funcionais
+- ✅ **Performance otimizada**: Carregamento sob demanda implementado
+
+**🎮 O JOGO ESTÁ PRONTO PARA SER JOGADO! 🎮**
+
+### 🔧 Correção Técnica Implementada:
+- **Análise do Schema:** Identificadas relações Manager ↔ Lineup, Manager ↔ Tactic, Manager ↔ SaveSlot
+- **Ordem de Exclusão Corrigida:** lineup → tactic → saveSlot → manager
+- **Logs de Debug:** Adicionados para acompanhar o processo de reset

--- a/app/game/actions.ts
+++ b/app/game/actions.ts
@@ -589,10 +589,15 @@ export async function playNextMatch(managerId: string) {
     throw new Error('No fixture to play')
   }
 
-  // Get fixtures from the SAME ROUND as the player's fixture across ALL divisions
+  // Get fixtures from the SAME ROUND NUMBER across ALL divisions
+  const { number: roundNumber, seasonId } = playerFixture.round
+  
   const roundFixtures = await prisma.fixture.findMany({
     where: {
-      roundId: playerFixture.roundId, // Only fixtures from the same round
+      round: { 
+        number: roundNumber, 
+        seasonId 
+      }, // All divisions in the same round number
       isPlayed: false
     },
     include: {
@@ -610,7 +615,7 @@ export async function playNextMatch(managerId: string) {
     ]
   })
 
-  console.log(`Simulating Round ${playerFixture.round.number}: ${roundFixtures.length} fixtures across all divisions`)
+  console.log(`Simulating Round ${roundNumber}: ${roundFixtures.length} fixtures across all divisions`)
 
   let playerMatchResult = null
 

--- a/src/ui/components/views/AllDivisionsView.tsx
+++ b/src/ui/components/views/AllDivisionsView.tsx
@@ -105,6 +105,27 @@ export default function AllDivisionsView() {
     return ''
   }
 
+  const getLegendItems = (level: number) => {
+    if (level === 1) {
+      return [
+        { color: 'bg-retro-red', label: 'Rebaixamento' },
+        { color: 'bg-retro-gray', label: 'Permanecem na Divisão' }
+      ]
+    } else if (level === 4) {
+      return [
+        { color: 'bg-retro-green', label: 'Promoção' },
+        { color: 'bg-retro-dark', label: 'Eliminação (Série D)' },
+        { color: 'bg-retro-gray', label: 'Permanecem na Divisão' }
+      ]
+    } else {
+      return [
+        { color: 'bg-retro-green', label: 'Promoção' },
+        { color: 'bg-retro-red', label: 'Rebaixamento' },
+        { color: 'bg-retro-gray', label: 'Permanecem na Divisão' }
+      ]
+    }
+  }
+
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
@@ -202,23 +223,13 @@ export default function AllDivisionsView() {
       {/* Legend */}
       <div className="card-retro">
         <h4 className="font-mono font-bold mb-2">LEGENDA:</h4>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-2 font-mono text-sm">
-          <div className="flex items-center">
-            <div className="w-4 h-4 bg-retro-green border border-black mr-2"></div>
-            <span>Promoção</span>
-          </div>
-          <div className="flex items-center">
-            <div className="w-4 h-4 bg-retro-red border border-black mr-2"></div>
-            <span>Rebaixamento</span>
-          </div>
-          <div className="flex items-center">
-            <div className="w-4 h-4 bg-retro-dark border border-black mr-2"></div>
-            <span>Eliminação (Série D)</span>
-          </div>
-          <div className="flex items-center">
-            <div className="w-4 h-4 bg-retro-gray border border-black mr-2"></div>
-            <span>Permanecem na Divisão</span>
-          </div>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-2 font-mono text-sm">
+          {getLegendItems(selectedDivision).map((item, index) => (
+            <div key={index} className="flex items-center">
+              <div className={`w-4 h-4 ${item.color} border border-black mr-2`}></div>
+              <span>{item.label}</span>
+            </div>
+          ))}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes division simulation to advance all divisions simultaneously and makes the 'All Divisions' legend dynamic based on the selected division.

Previously, only the player's division progressed because the fixture query was limited by `roundId`, which is unique per division. This PR updates the query to use `roundNumber` and `seasonId`, ensuring all divisions advance together. Additionally, the static legend in `AllDivisionsView` now dynamically displays only relevant promotion/relegation labels for the selected division, improving clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-f05fe110-ab4e-4a6f-bf8f-f4913face2c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f05fe110-ab4e-4a6f-bf8f-f4913face2c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

